### PR TITLE
Drop dependency on BeatifulSoup and use Cablemap's parser

### DIFF
--- a/cableimporter.py
+++ b/cableimporter.py
@@ -49,7 +49,7 @@ class CableImporter(object):
         """
         self.cable_list=[]
         try:
-            for cable in cable_from_directory(self.data_directory):
+            for cable in cables_from_directory(self.data_directory):
                 self.process_cable(cable, overwrite)
                 if maxcables is not None and len(self.cable_list) >= maxcables:
                     break

--- a/cableimporter.py
+++ b/cableimporter.py
@@ -22,7 +22,7 @@ from os.path import join
 from datetime import datetime
 from datamodel import initEdges
 from mongodbhandler import CablegateDatabase
-from cablemap.core.utils import cables_from_directory
+from cablemap.core import cables_from_directory
 
 
 class CableImporter(object):
@@ -64,8 +64,8 @@ class CableImporter(object):
         cable = self.mongodb.cables.find_one({'_id': cable_id})
         if not overwrite and cable is not None:
             logging.info('CABLE ALREADY EXISTS : SKIPPING')
-            self.cable_list += [cable_id]
-            logging.info("cables processed = %d"%len(self.cable_id))
+            self.cable_list.append(cable_id)
+            logging.info("cables processed = %d, %s" % (len(self.cable_id), cb.reference_id))
             return
         ## updates metas without erasing edges
         if cable is None:
@@ -83,5 +83,5 @@ class CableImporter(object):
             'category': "Document"
         })
         self.mongodb.cables.save(cable)
-        self.cable_list += [cable_id]
-        logging.info("cables processed = %d"%len(self.cable_list))
+        self.cable_list.append(cable_id)
+        logging.info(u"cables processed = %d, %s" % (len(cable_id), cb.reference_id))

--- a/cableimporter.py
+++ b/cableimporter.py
@@ -65,7 +65,7 @@ class CableImporter(object):
         if not overwrite and cable is not None:
             logging.info('CABLE ALREADY EXISTS : SKIPPING')
             self.cable_list.append(cable_id)
-            logging.info("cables processed = %d, %s" % (len(self.cable_id), cb.reference_id))
+            logging.info("cables processed = %d, %s" % (len(self.cable_list), cb.reference_id))
             return
         ## updates metas without erasing edges
         if cable is None:
@@ -84,4 +84,4 @@ class CableImporter(object):
         })
         self.mongodb.cables.save(cable)
         self.cable_list.append(cable_id)
-        logging.info(u"cables processed = %d, %s" % (len(cable_id), cb.reference_id))
+        logging.info(u"cables processed = %d, %s" % (len(self.cable_list), cb.reference_id))

--- a/cableimporter.py
+++ b/cableimporter.py
@@ -60,10 +60,9 @@ class CableImporter(object):
         """
         Cable Content extractor
         """
-        title = cb.subject.title()
         cable_id = cb.reference_id
         cable = self.mongodb.cables.find_one({'_id': cable_id})
-        if overwrite is False and cable is not None:
+        if not overwrite and cable is not None:
             logging.info('CABLE ALREADY EXISTS : SKIPPING')
             self.cable_list += [cable_id]
             logging.info("cables processed = %d"%len(self.cable_id))
@@ -71,18 +70,15 @@ class CableImporter(object):
         ## updates metas without erasing edges
         if cable is None:
             cable = initEdges({})
-        cablecontent = cb.content
-        date_time = datetime.strptime(cb.created, "%Y-%m-%d %H:%M")
         ## overwrite metas informations without erasing edges
         cable.update({
             # auto index
-            #'_id' : cablenode.id,
-            '_id' : "%s"%cable_id,
-            'label' : title,
-            'start' : date_time,
+            '_id' : "%s" % cable_id,
+            'label' : cb.subject.title(),
+            'start' : datetime.strptime(cb.created, "%Y-%m-%d %H:%M"),
             'classification' : cb.classification,
             'embassy' : "%s" % cb.origin,
-            'content' : cablecontent,
+            'content' : cb.content,
             'category': "Document"
         })
         self.mongodb.cables.save(cable)

--- a/cableimporter.py
+++ b/cableimporter.py
@@ -70,11 +70,12 @@ class CableImporter(object):
         ## updates metas without erasing edges
         if cable is None:
             cable = initEdges({})
+        cable_title = cb.subject.title() if cb.subject else u''
         ## overwrite metas informations without erasing edges
         cable.update({
             # auto index
             '_id' : "%s" % cable_id,
-            'label' : cb.subject.title(),
+            'label' : cable_title,
             'start' : datetime.strptime(cb.created, "%Y-%m-%d %H:%M"),
             'classification' : cb.classification,
             'embassy' : "%s" % cb.origin,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from distutils.core import setup
 setup (
     name = 'cablegate_semnet',
     packages = find_packages(),
-    install_requires = ['bson','beautifulsoup','nltk','TinasoftPytextminer'],
+    install_requires = ['bson','cablemap.core','nltk'],
     scripts = ['execute.py'],
     version = __version__,
     url = __url__,


### PR DESCRIPTION
Cablemap's parser delivers better results (i.e. better subjects) than the currently used BeautifulSoup parser which relies on the data delivered by WikiLeaks. The subjects delivered by WikiLeaks are often incomplete or contain too much information like references to other cables. 
Further, the usage of Cablemap would reduce your code to import cables considerably. It adds a dependency to cablemap.core, though.
